### PR TITLE
Update plugin to use consolidated bkmr LSP command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@
 # Requirements:
 # - JDK 17+
 # - Gradle (via gradlew)
-# - bkmr-lsp binary (for LSP integration)
+# - bkmr binary (for LSP integration)
 # - Optional: GitHub CLI (gh) for release management
 # ==============================================================================
 
@@ -276,13 +276,13 @@ check-github-token:  ## check if GITHUB_TOKEN is set
 LSP_INTEGRATION:  ## ##################################################################
 
 .PHONY: log-lsp
-log-lsp:  ## view LSP server logs (from bkmr-lsp project)
+log-lsp:  ## view LSP server logs (from bkmr lsp)
 	@echo "Viewing LSP server logs..."
 	@if [ -f "/tmp/lsp-bkmr.log" ]; then \
 		tail -f /tmp/lsp-bkmr.log; \
 	else \
 		echo "LSP log file not found at /tmp/lsp-bkmr.log"; \
-		echo "Make sure bkmr-lsp server is running and configured for logging."; \
+		echo "Make sure bkmr lsp server is running and configured for logging."; \
 	fi
 
 .PHONY: log-lsp-err
@@ -292,7 +292,7 @@ log-lsp-err:  ## view LSP server error logs
 		tail -f /tmp/lsp-bkmr-err.log; \
 	else \
 		echo "LSP error log file not found at /tmp/lsp-bkmr-err.log"; \
-		echo "Check if bkmr-lsp server is configured for error logging."; \
+		echo "Check if bkmr lsp server is configured for error logging."; \
 	fi
 
 ################################################################################

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bkmr-intellij-plugin
 
-IntelliJ Platform plugin for [bkmr](https://github.com/sysid/bkmr-lsp) snippet manager integration via Language Server Protocol (LSP).
+IntelliJ Platform plugin for [bkmr](https://github.com/sysid/bkmr) snippet manager integration via Language Server Protocol (LSP).
 
 ## Features
 
@@ -9,7 +9,7 @@ IntelliJ Platform plugin for [bkmr](https://github.com/sysid/bkmr-lsp) snippet m
 - **Language-Aware Filtering**: Snippets automatically filtered by file type (Rust, Python, JavaScript, etc.)
 - **Universal Snippets**: Language-agnostic snippets with automatic syntax translation
 - **Cross-Platform Compatibility**: Works across all JetBrains IDEs (IntelliJ IDEA, PyCharm, WebStorm, CLion, etc.)
-- **LSP Integration**: Seamless integration with bkmr-lsp server (version 0.5.0+)
+- **LSP Integration**: Seamless integration with bkmr's built-in LSP server
 - **Filepath Comment Insertion**: Automatically insert filepath as comment at file beginning
 - **Smart Comment Detection**: Automatic comment syntax detection for 20+ file types
 - **Configurable Settings**: Binary path and debug logging options
@@ -68,8 +68,8 @@ fn main() {
 ## Requirements
 
 ### For Snippet Completion
-- **bkmr-lsp binary**: Version 0.5.0+ available in PATH or configured in plugin settings
-- **bkmr command-line tool**: Version 4.24.0+ with snippets configured and `--interpolate` support
+- **bkmr command-line tool**: Version 4.24.0+ with built-in LSP server (`bkmr lsp` command)
+- Snippets must be configured in bkmr with `--interpolate` support
 
 ### For Filepath Comment Insertion
 - **No additional requirements**: This feature works independently of the LSP server
@@ -135,7 +135,7 @@ make init
 Access plugin settings via **File → Settings → Tools → bkmr**:
 
 - **Enable LSP Integration**: Toggle LSP-based completion (affects snippet completion only)
-- **Binary Path**: Path to bkmr-lsp executable (required for snippet completion)
+- **Binary Path**: Path to bkmr executable (required for snippet completion)
 - **Debug Logging**: Enable detailed logging for troubleshooting
 
 **Note**: The filepath comment insertion feature works independently of these settings and doesn't require LSP server configuration.
@@ -144,7 +144,7 @@ Access plugin settings via **File → Settings → Tools → bkmr**:
 
 1. Download from [JetBrains Marketplace](https://plugins.jetbrains.com)
 2. Or install manually: **File → Settings → Plugins → Install Plugin from Disk**
-3. **Optional**: Configure bkmr-lsp binary path in settings for snippet completion
+3. **Optional**: Configure bkmr binary path in settings for snippet completion
 
 **Quick Start**: After installation, you can immediately use the filepath comment feature via `Cmd+Shift+A` → "Bkmr: Insert Filepath Comment".
 
@@ -157,8 +157,8 @@ Access plugin settings via **File → Settings → Tools → bkmr**:
 
 ### Snippet Completion
 - Completion only works in project context (scratch files are ignored)
-- Requires bkmr-lsp server to be running and properly configured
-- LSP server won't start if bkmr-lsp binary is not found in PATH or settings
+- Requires bkmr LSP server to be running and properly configured
+- LSP server won't start if bkmr binary is not found in PATH or settings
 
 ### Filepath Comment Insertion
 - Works with all text files, including scratch files
@@ -168,7 +168,7 @@ Access plugin settings via **File → Settings → Tools → bkmr**:
 ## Troubleshooting
 
 ### Snippet Completion Not Working
-1. Check that bkmr-lsp is installed and version 0.5.0+: `bkmr-lsp --version`
+1. Check that bkmr is installed with LSP support: `bkmr --version`
 2. Verify bkmr has snippets: `bkmr search -t _snip_`
 3. Test manual completion: Type text and press Ctrl+Space to see if snippets appear
 4. Check plugin settings: **File → Settings → Tools → bkmr**

--- a/src/main/kotlin/com/sysid/bkmr/BkmrLspServerSupportProvider.kt
+++ b/src/main/kotlin/com/sysid/bkmr/BkmrLspServerSupportProvider.kt
@@ -20,7 +20,7 @@ class BkmrLspServerSupportProvider : LspServerSupportProvider {
         }
 
         val settings = BkmrSettings.getInstance()
-        if (!settings.enableLspIntegration || settings.bkmrLspBinaryPath.isBlank()) {
+        if (!settings.enableLspIntegration || settings.bkmrBinaryPath.isBlank()) {
             return
         }
 
@@ -57,7 +57,7 @@ class BkmrLspServerSupportProvider : LspServerSupportProvider {
     }
 }
 
-class BkmrLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor(project, "bkmr-lsp") {
+class BkmrLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor(project, "bkmr") {
 
     override fun isSupportedFile(file: VirtualFile): Boolean {
         // Support all text files, exclude only known binary types
@@ -80,7 +80,8 @@ class BkmrLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor
         val settings = BkmrSettings.getInstance()
 
         return GeneralCommandLine().apply {
-            exePath = settings.bkmrLspBinaryPath
+            exePath = settings.bkmrBinaryPath
+            addParameter("lsp")
             withWorkDirectory(project.basePath)
             withEnvironment("RUST_LOG", if (settings.enableDebugLogging) "debug" else "info")
         }

--- a/src/main/kotlin/com/sysid/bkmr/settings/BkmrConfigurable.kt
+++ b/src/main/kotlin/com/sysid/bkmr/settings/BkmrConfigurable.kt
@@ -11,7 +11,7 @@ import javax.swing.JComponent
 class BkmrConfigurable : Configurable {
 
     private lateinit var enableLspCheckBox: JBCheckBox
-    private lateinit var bkmrLspBinaryField: TextFieldWithBrowseButton
+    private lateinit var bkmrBinaryField: TextFieldWithBrowseButton
     private lateinit var enableDebugLoggingCheckBox: JBCheckBox
 
     override fun getDisplayName(): String = "bkmr"
@@ -22,11 +22,11 @@ class BkmrConfigurable : Configurable {
         enableLspCheckBox = JBCheckBox("Enable LSP Integration", settings.enableLspIntegration)
         enableDebugLoggingCheckBox = JBCheckBox("Enable Debug Logging", settings.enableDebugLogging)
 
-        bkmrLspBinaryField = TextFieldWithBrowseButton().apply {
-            text = settings.bkmrLspBinaryPath
+        bkmrBinaryField = TextFieldWithBrowseButton().apply {
+            text = settings.bkmrBinaryPath
             addBrowseFolderListener(
-                "Select bkmr-lsp Binary",
-                "Choose the bkmr-lsp executable file",
+                "Select bkmr Binary",
+                "Choose the bkmr executable file",
                 null,
                 FileChooserDescriptorFactory.createSingleFileDescriptor()
             )
@@ -36,9 +36,9 @@ class BkmrConfigurable : Configurable {
             row("Enable LSP Integration:") {
                 cell(enableLspCheckBox)
             }
-            row("bkmr-lsp Binary Path:") {
-                cell(bkmrLspBinaryField)
-                    .comment("Path to the bkmr-lsp executable")
+            row("bkmr Binary Path:") {
+                cell(bkmrBinaryField)
+                    .comment("Path to the bkmr executable")
             }
             row("Enable Debug Logging:") {
                 cell(enableDebugLoggingCheckBox)
@@ -58,21 +58,21 @@ class BkmrConfigurable : Configurable {
     override fun isModified(): Boolean {
         val settings = BkmrSettings.getInstance()
         return enableLspCheckBox.isSelected != settings.enableLspIntegration ||
-            bkmrLspBinaryField.text != settings.bkmrLspBinaryPath ||
+            bkmrBinaryField.text != settings.bkmrBinaryPath ||
             enableDebugLoggingCheckBox.isSelected != settings.enableDebugLogging
     }
 
     override fun apply() {
         val settings = BkmrSettings.getInstance()
         settings.enableLspIntegration = enableLspCheckBox.isSelected
-        settings.bkmrLspBinaryPath = bkmrLspBinaryField.text
+        settings.bkmrBinaryPath = bkmrBinaryField.text
         settings.enableDebugLogging = enableDebugLoggingCheckBox.isSelected
     }
 
     override fun reset() {
         val settings = BkmrSettings.getInstance()
         enableLspCheckBox.isSelected = settings.enableLspIntegration
-        bkmrLspBinaryField.text = settings.bkmrLspBinaryPath
+        bkmrBinaryField.text = settings.bkmrBinaryPath
         enableDebugLoggingCheckBox.isSelected = settings.enableDebugLogging
     }
 }

--- a/src/main/kotlin/com/sysid/bkmr/settings/BkmrConfigurable.kt
+++ b/src/main/kotlin/com/sysid/bkmr/settings/BkmrConfigurable.kt
@@ -1,7 +1,7 @@
 // File: src/main/kotlin/com/sysid/bkmr/settings/BkmrConfigurable.kt
 package com.sysid.bkmr
 
-import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.ui.components.JBCheckBox
@@ -24,12 +24,15 @@ class BkmrConfigurable : Configurable {
 
         bkmrBinaryField = TextFieldWithBrowseButton().apply {
             text = settings.bkmrBinaryPath
-            addBrowseFolderListener(
-                "Select bkmr Binary",
-                "Choose the bkmr executable file",
-                null,
-                FileChooserDescriptorFactory.createSingleFileDescriptor()
-            )
+            val descriptor = FileChooserDescriptor(true, false, false, false, false, false).apply {
+                title = "Select bkmr Binary"
+                description = "Choose the bkmr executable file"
+            }
+            addActionListener {
+                com.intellij.openapi.fileChooser.FileChooser.chooseFile(descriptor, null, null) { file ->
+                    text = file.path
+                }
+            }
         }
 
         return panel {

--- a/src/main/kotlin/com/sysid/bkmr/settings/BkmrSettings.kt
+++ b/src/main/kotlin/com/sysid/bkmr/settings/BkmrSettings.kt
@@ -13,7 +13,7 @@ import com.intellij.openapi.util.SystemInfo
 class BkmrSettings : PersistentStateComponent<BkmrSettings> {
 
     var enableLspIntegration: Boolean = true
-    var bkmrLspBinaryPath: String = findDefaultBinaryPath()
+    var bkmrBinaryPath: String = findDefaultBinaryPath()
     var enableDebugLogging: Boolean = false
 
     companion object {
@@ -21,8 +21,8 @@ class BkmrSettings : PersistentStateComponent<BkmrSettings> {
             ApplicationManager.getApplication().getService(BkmrSettings::class.java)
 
         private fun findDefaultBinaryPath(): String = when {
-            SystemInfo.isWindows -> "bkmr-lsp.exe"
-            else -> "bkmr-lsp"
+            SystemInfo.isWindows -> "bkmr.exe"
+            else -> "bkmr"
         }
     }
 
@@ -30,7 +30,7 @@ class BkmrSettings : PersistentStateComponent<BkmrSettings> {
 
     override fun loadState(state: BkmrSettings) {
         enableLspIntegration = state.enableLspIntegration
-        bkmrLspBinaryPath = state.bkmrLspBinaryPath
+        bkmrBinaryPath = state.bkmrBinaryPath
         enableDebugLogging = state.enableDebugLogging
     }
 }


### PR DESCRIPTION
## Summary

This PR updates the IntelliJ plugin to use the consolidated bkmr CLI with built-in LSP server functionality, replacing the separate bkmr-lsp binary.

## Changes

- **LSP Command Update**: Changed from standalone `bkmr-lsp` binary to `bkmr lsp` subcommand
- **Settings Refactoring**: Renamed `bkmrLspBinaryPath` to `bkmrBinaryPath` throughout the codebase for clarity
- **UI Updates**: Updated all user-facing labels and help text to reference "bkmr" instead of "bkmr-lsp"
- **Deprecation Fixes**: Fixed IntelliJ Platform API deprecation warnings in BkmrConfigurable.kt

## Background

The bkmr-lsp server has been consolidated into the main bkmr CLI tool at https://github.com/sysid/bkmr. This change aligns the plugin with this architectural update while maintaining all existing functionality.

## Migration Notes

Users will need to:
Update to the latest bkmr CLI that includes the LSP server: `brew install bkmr`


## Compatibility
